### PR TITLE
Change type hint from Create to Category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## 2021-10-04
+### Fixed
+- type hint on `Shopgate\ConnectSdk\Service\BulkImport\Feed\Category::add()` now expects an object of type `Category` instead of `Category\Create`
+
 ## [1.4.0] - 2021-05-25
 ### Added
 - Segmentation service support

--- a/src/Service/BulkImport/Feed/Category.php
+++ b/src/Service/BulkImport/Feed/Category.php
@@ -25,14 +25,13 @@ namespace Shopgate\ConnectSdk\Service\BulkImport\Feed;
 use Shopgate\ConnectSdk\Service\BulkImport\Feed;
 use Shopgate\ConnectSdk\Service\BulkImport\Handler\Stream;
 use Shopgate\ConnectSdk\Service\BulkImport\Handler\File;
-use Shopgate\ConnectSdk\Dto\Catalog\Category\Create;
 
 class Category extends Feed
 {
     /**
-     * @param Create $category
+     * @param \Shopgate\ConnectSdk\Dto\Catalog\Category $category
      */
-    public function add(Create $category)
+    public function add(\Shopgate\ConnectSdk\Dto\Catalog\Category $category)
     {
         switch ($this->handlerType) {
             case Stream::HANDLER_TYPE:


### PR DESCRIPTION
# Fix type hint in `BulkImport\Feed\Category::add()`

## Description
We started to use Your SDK in our company for one of our newest applications. One thing that popped out while implementing the BulkUpload, was the type-hint for the `add()` -method of the class `Shopgate\ConnectSdk\Service\BulkImport\Feed\Category`.

Since it still works because `Create` extends `Category`, it is a more specific type and causes errors from static analysis software such as Psalm. Further, all setters on an `Create` -object return a `Category` -object, so this should be the correct type accepted by the method.

If You accept my PR, and since we already have October, I would really appreciate it if You would label it with `hacktoberfest-accepted`. Thank You very much in advance!

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
